### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
 
     - name: Build cvc5
       run: |
+        cd cvc5/
         ./configure.sh production --auto-download --python-bindings
         cd build/
         make -j${{ env.num_proc }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,18 +39,17 @@ jobs:
     - name: Setup dependencies cache
       uses: actions/cache@v2
       with:
-        path: cvc5/build-shared/deps
+        path: cvc5/build/deps
         key: cvc5-z3py-compat-deps-${{ hashFiles('cvc5/cmake/**') }}-${{ hashFiles('.github/**') }}
 
-    - name: Configure and build
-      id: configure-and-build
-      uses: ./cvc5/.github/actions/configure-and-build
-      with:
-        configure-config: production --auto-download --python-bindings
-        build-static: false
+    - name: Build cvc5
+      run: |
+        ./configure.sh production --auto-download --python-bindings
+        cd build/
+        make -j${{ env.num_proc }}
 
     - name: Test z3py compatibility API
       run: |
         make test
       env:
-        PYTHONPATH: cvc5/build_shared/src/api/python:.
+        PYTHONPATH: cvc5/build/src/api/python:.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+on: [push, pull_request]
+name: CI
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: actions/checkout@v2
+      with:
+        repository: cvc5/cvc5
+        path: cvc5
+      
+    - name: Install dependencies
+      uses: cvc5/.github/actions/install-dependencies
+      with:
+        with-documentation: false
+        with-python-bindings: true
+
+    - name: Setup caches
+      uses: cvc5/.github/actions/setup-cache
+      with:
+        cache-key: cvc5-z3py-compat
+
+    - name: Configure and build
+      id: configure-and-build
+      uses: cvc5/.github/actions/configure-and-build
+      with:
+        configure-config: production --auto-download --python-bindings
+        build-static: false
+
+    - name: Test z3py compatibility API
+      run: |
+        make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,19 @@ jobs:
         path: cvc5
       
     - name: Install dependencies
-      uses: cvc5/.github/actions/install-dependencies
+      uses: ./cvc5/.github/actions/install-dependencies
       with:
         with-documentation: false
         with-python-bindings: true
 
     - name: Setup caches
-      uses: cvc5/.github/actions/setup-cache
+      uses: ./cvc5/.github/actions/setup-cache
       with:
         cache-key: cvc5-z3py-compat
 
     - name: Configure and build
       id: configure-and-build
-      uses: cvc5/.github/actions/configure-and-build
+      uses: ./cvc5/.github/actions/configure-and-build
       with:
         configure-config: production --auto-download --python-bindings
         build-static: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,27 @@ jobs:
         with-documentation: false
         with-python-bindings: true
 
-    - name: Setup caches
-      uses: ./cvc5/.github/actions/setup-cache
+    - name: Setup ccache cache
+      uses: actions/cache@v2
       with:
-        cache-key: cvc5-z3py-compat
+        path: ccache-dir
+        key: cvc5-z3py-compat-ccache-${{ github.sha }}
+        restore-keys: cvc5-z3py-compat-ccache-
+
+    - name: Configure ccache
+      shell: bash
+      run: |
+        ccache --set-config=cache_dir=${{ github.workspace }}/ccache-dir
+        ccache --set-config=compression=true
+        ccache --set-config=compression_level=6
+        ccache -M 500M
+        ccache -z
+
+    - name: Setup dependencies cache
+      uses: actions/cache@v2
+      with:
+        path: cvc5/build-shared/deps
+        key: cvc5-z3py-compat-deps-${{ hashFiles('cvc5/cmake/**') }}-${{ hashFiles('.github/**') }}
 
     - name: Configure and build
       id: configure-and-build
@@ -35,3 +52,5 @@ jobs:
     - name: Test z3py compatibility API
       run: |
         make test
+      env:
+        PYTHONPATH: cvc5/build_shared/src/api/python:.


### PR DESCRIPTION
This PR adds a simple CI job. It compiles cvc5 (properly caching, just as we do for cvc5 itself) and then calls `make test`.