### PR TITLE
Avoid importing by package name

### DIFF
--- a/cvc5_z3py_compat/z3printer.py
+++ b/cvc5_z3py_compat/z3printer.py
@@ -12,7 +12,7 @@ import io
 
 import itertools as it
 
-from cvc5_z3py_compat import z3 as cvc
+from . import z3 as cvc
 import cvc5 as pc
 from cvc5 import Kind
 


### PR DESCRIPTION
We want to integrate this code into the base python API, forming a unified package. This inherently changes the package name: here, it is `cvc5_z3py_compat`, while it is `cvc5.pythonic` in the actual package. For this to work, we can only use `from . import ...`, but not `from cvc5_z3py_compat import ...` in any code that is actually relocated.
